### PR TITLE
Changed the file type filters for importing data.

### DIFF
--- a/Source/Applications/IMFViewer/IMFController.cpp
+++ b/Source/Applications/IMFViewer/IMFController.cpp
@@ -96,11 +96,12 @@ void IMFController::importFile(IMFViewer_UI* instance)
   jpegSuffixStr.prepend("*.");
 
   // Open a file in the application
-  QString filter = tr("All Files (*.*);;"
+  QString filter = tr("Data Files (*.dream3d *.vtk *.stl %1 %3 %3);;"
                       "DREAM.3D Files (*.dream3d);;"
-                   "Image Files (%1 %2 %3);;"
+                      "Image Files (%1 %2 %3);;"
                       "VTK Files (*.vtk);;"
-                      "STL Files (*.stl)").arg(pngSuffixStr).arg(tiffSuffixStr).arg(jpegSuffixStr);
+                      "STL Files (*.stl);;"
+                      "All Files(*.*)").arg(pngSuffixStr).arg(tiffSuffixStr).arg(jpegSuffixStr);
   QString filePath = QFileDialog::getOpenFileName(instance, "Open Input File", m_OpenDialogLastDirectory, filter);
   if (filePath.isEmpty())
   {


### PR DESCRIPTION
Changed the default filter for importing data from All Files to a new Data Files filter that allows only the extensions accepted by the other filters.  This ensures that only files that can be imported are displayed without changing the filter to match the specific type of file being imported.