### PR TITLE
feature/filter menu

### DIFF
--- a/Source/Applications/IMFViewer/IMFViewerApplication.cpp
+++ b/Source/Applications/IMFViewer/IMFViewerApplication.cpp
@@ -59,8 +59,6 @@ IMFViewerApplication::IMFViewerApplication(int& argc, char** argv) :
 {
 //  loadStyleSheet("light");
 
-  createApplicationMenu();
-
   // Connection to update the recent files list on all windows when it changes
   QtSRecentFileList* recentsList = QtSRecentFileList::instance();
   connect(recentsList, SIGNAL(fileListChanged(const QString&)), this, SLOT(updateRecentFileList(const QString&)));
@@ -72,31 +70,6 @@ IMFViewerApplication::IMFViewerApplication(int& argc, char** argv) :
 IMFViewerApplication::~IMFViewerApplication()
 {
   delete m_Controller;
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void IMFViewerApplication::createApplicationMenu()
-{
-  SIMPLViewMenuItems* menuItems = SIMPLViewMenuItems::Instance();
-
-  m_ApplicationMenuBar = new QMenuBar();
-  QMenu* fileMenu = new QMenu("File", m_ApplicationMenuBar);
-
-  QAction* importAction = new QAction("Import");
-  importAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_I));
-  connect(importAction, &QAction::triggered, this, &IMFViewerApplication::importFile);
-  fileMenu->addAction(importAction);
-
-  fileMenu->addSeparator();
-
-  QMenu* recentsMenu = menuItems->getMenuRecentFiles();
-  QAction* clearRecentsAction = menuItems->getActionClearRecentFiles();
-  fileMenu->addMenu(recentsMenu);
-
-
-  m_ApplicationMenuBar->addMenu(fileMenu);
 }
 
 // -----------------------------------------------------------------------------
@@ -195,10 +168,6 @@ IMFViewer_UI* IMFViewerApplication::getNewIMFViewerInstance()
   newInstance->setAttribute(Qt::WA_DeleteOnClose);
   newInstance->setWindowTitle("IMF Viewer");
 
-  #if defined(Q_OS_WIN)
-  newInstance->setMenuBar(m_ApplicationMenuBar);
-  #endif
-
   setActiveInstance(newInstance);
 
   return newInstance;
@@ -220,18 +189,19 @@ void IMFViewerApplication::loadStyleSheet(const QString &sheetName)
 // -----------------------------------------------------------------------------
 void IMFViewerApplication::setActiveInstance(IMFViewer_UI* instance)
 {
-  if (instance == nullptr)
+  if (nullptr == instance)
   {
     return;
   }
 
   // Disconnections from the old instance
-  if (m_ActiveInstance != nullptr)
+  if (nullptr != m_ActiveInstance)
   {
-
+    disconnect(instance, &IMFViewer_UI::importSignal, this, &IMFViewerApplication::importFile);
   }
 
   // Connections to the new instance
+  connect(instance, &IMFViewer_UI::importSignal, this, &IMFViewerApplication::importFile);
 
   m_ActiveInstance = instance;
 }

--- a/Source/Applications/IMFViewer/IMFViewerApplication.h
+++ b/Source/Applications/IMFViewer/IMFViewerApplication.h
@@ -69,14 +69,8 @@ private slots:
 private:
   IMFViewer_UI*                           m_ActiveInstance = nullptr;
   IMFController*                          m_Controller = nullptr;
-  QMenuBar*                               m_ApplicationMenuBar = nullptr;
 
   QString                                 m_OpenDialogLastDirectory = "";
-
-  /**
-   * @brief createApplicationMenu
-   */
-  void createApplicationMenu();
 
   /**
    * @brief loadStyleSheet

--- a/Source/Applications/IMFViewer/IMFViewer_UI.cpp
+++ b/Source/Applications/IMFViewer/IMFViewer_UI.cpp
@@ -39,6 +39,7 @@
 
 #include "SVWidgetsLib/QtSupport/QtSSettings.h"
 #include "SVWidgetsLib/QtSupport/QtSRecentFileList.h"
+#include "SVWidgetsLib/Widgets/SIMPLViewMenuItems.h"
 
 #include "ui_IMFViewer_UI.h"
 
@@ -82,6 +83,8 @@ void IMFViewer_UI::setupGui()
 
   m_Internals->vsWidget->setFilterView(m_Internals->treeView);
   m_Internals->vsWidget->setInfoWidget(m_Internals->infoWidget);
+
+  createMenu();
 }
 
 // -----------------------------------------------------------------------------
@@ -169,3 +172,44 @@ void IMFViewer_UI::writeWindowSettings(QtSSettings* prefs)
   prefs->endGroup();
 }
 
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+QMenuBar* IMFViewer_UI::getMenuBar()
+{
+  return m_MenuBar;
+}
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void IMFViewer_UI::createMenu()
+{
+  SIMPLViewMenuItems* menuItems = SIMPLViewMenuItems::Instance();
+
+  m_MenuBar = new QMenuBar();
+
+  // File Menu
+  QMenu* fileMenu = new QMenu("File", m_MenuBar);
+
+  QAction* importAction = new QAction("Import");
+  importAction->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_I));
+  connect(importAction, &QAction::triggered, this, &IMFViewer_UI::importSignal);
+  //connect(importAction, &QAction::triggered, this, &IMFViewerApplication::importFile);
+  fileMenu->addAction(importAction);
+
+  fileMenu->addSeparator();
+
+  QMenu* recentsMenu = menuItems->getMenuRecentFiles();
+  QAction* clearRecentsAction = menuItems->getActionClearRecentFiles();
+  fileMenu->addMenu(recentsMenu);
+
+  m_MenuBar->addMenu(fileMenu);
+
+  // Add Filter Menu
+  QMenu* filterMenu = m_Internals->vsWidget->getFilterMenu();
+  m_MenuBar->addMenu(filterMenu);
+
+  // Apply Menu Bar
+  setMenuBar(m_MenuBar);
+}

--- a/Source/Applications/IMFViewer/IMFViewer_UI.h
+++ b/Source/Applications/IMFViewer/IMFViewer_UI.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <QtWidgets/QMainWindow>
+#include <QtWidgets/QMenuBar>
 
 #include "SIMPLib/DataContainers/DataContainerArray.h"
 
@@ -62,11 +63,25 @@ class IMFViewer_UI : public QMainWindow
      */
     void importData(const QString &filePath);
 
+    /**
+    * @brief Returns the QMenuBar for the window
+    * @return
+    */
+    QMenuBar* getMenuBar();
+
+  signals:
+    void importSignal();
+
   protected:
     /**
      * @brief setupGui
      */
     void setupGui();
+
+    /**
+    * @brief createApplicationMenu
+    */
+    void createMenu();
 
     /**
      * @brief readSettings
@@ -93,6 +108,8 @@ class IMFViewer_UI : public QMainWindow
   private:
     class vsInternals;
     vsInternals*                        m_Internals;
+
+    QMenuBar*                           m_MenuBar;
 
     IMFViewer_UI(const IMFViewer_UI&); // Copy Constructor Not Implemented
     void operator=(const IMFViewer_UI&); // Operator '=' Not Implemented


### PR DESCRIPTION
* Moved the QMenuBar from IMFViewerApplication to IMFViewer_UI and created a signal for the active IMFViewer_UI to trigger a slot in the IMFViewerApplication.

Because of the way Qt handles the system-wide menu bar, having the menu bar attached the window should be plenty to trigger the same menu bar to appear in systems that use a system-wide menu bar instead.